### PR TITLE
added back first get; removed package reference

### DIFF
--- a/Black.Zinc.Spitz.Api/Black.Zinc.Spitz.Api.csproj
+++ b/Black.Zinc.Spitz.Api/Black.Zinc.Spitz.Api.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.9" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>

--- a/Black.Zinc.Spitz.Api/Catalog/CatalogController.cs
+++ b/Black.Zinc.Spitz.Api/Catalog/CatalogController.cs
@@ -8,6 +8,21 @@ namespace Black.Zinc.Spitz.Api.Controllers
     public class CatalogController : ControllerBase
     {
 
+         //added old version back in after looking at the examples
+         [HttpGet]
+         public IActionResult GetItems()
+         {
+             var items = new List<Item>()
+             {
+               new Item("Shirt", "Ohio State shirt.", "Nike", 29.99m),
+               new Item("Shorts", "Ohio State shorts.", "Nike", 44.99m)
+             };
+    
+             return Ok(items);
+         }
+         //end of alteration
+         
+         
          // step 3 not sure where it goes or if it ovverides the old version so i will add it here
          [HttpGet("{id:int}")]
          public IActionResult GetItem(int id)


### PR DESCRIPTION
added back the first httpGet after looking at the examples and then removed package reference for microsoft.asp.net
<PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.9" /> 
because things were not working with the addition of this line
#2 